### PR TITLE
Transition to index-based references

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,40 @@ with any desired parameters at the top level within the yaml file::
     dummy_stage1:
         classname: OtherDummyStage
 
+You can also specify specific datasets to load that is linked to the current
+loop dataset with the `requires` field::
+
+    dummy_stage_requires:
+        classname: DummyStage
+        requires:
+            - <path to a dataset that has source <-> dset references>
+            - <path to a second dataset with source <-> dset references>
+
+This will load a ``numpy`` masked array into the ``cache`` under a key of the
+same path.
+
+You can specify complex linking paths to load data from references to references
+(or references to references to references ...) by specifying a path and a
+name:
+
+    dummy_stage_complex_requires:
+        classname: DummyStage
+        requires:
+            - name: <name to use in the cache>
+              path: [<path to first dataset>, <path to second dataset>, ...]
+
+which will load the data at ``source -> <first dataset> -> <second dataset>``.
+
+Finally, you can also indicate if you just want to load an index into the final
+dataset (rather than the data) with the ``index_only`` flag::
+
+    dummy_stage_index_requires:
+        classname: DummyStage
+        requires:
+            - name: <name to use in cache>
+              path: [<first dataset>, <second dataset>]
+              index_only: True
+
 # writing an `H5FlowStage`
 
 Any `H5FlowStage`-inheriting class has 4 main components:

--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ Converting this into a dataset that can be broadcast back into either the `A` or
     b2a = dereference(
         f['/B/data'],       # dataset to load, shape: (M,)
         f['/A/ref/B/ref'],  # references to use, shape: (L,)
-        f['/A/ref/B/ref_region'], # lookup regions in references, shape: (N,), special dtype (see below)
-        as_masked = True    # return a numpy masked array
+        f['/A/ref/B/ref_region'] # lookup regions in references, shape: (N,), special dtype (see below)
         )
     b2a.shape # (N,n), where n is the max number of B items associated with a row in A
     b2a.dtype == f['/B/data'].dtype # True!
@@ -133,8 +132,7 @@ And the inverse relationships can be found by redefining the "ref_direction":::
         f['/A/data'],       # dataset to load, shape: (N,)
         f['/A/ref/B/ref'],  # references to use, shape: (L,)
         f['/B/ref/A/ref_region'], # lookup regions in references, shape: (M,)
-        ref_direction = (1,0), # now use references from 1->0 (B->A) [default is (0,1)]
-        as_masked = True    # return a numpy masked array
+        ref_direction = (1,0) # now use references from 1->0 (B->A) [default is (0,1)]
         )
     a2b.shape # (M,m), where m is the max number of A items associated with a row in B
     a2b.dtype == f['/A/data'].dtype # True!
@@ -147,8 +145,7 @@ to load, e.g. to load only the first 100 references of A->B::
         f['/B/data'],       # dataset to load, shape: (M,)
         f['/A/ref/B/ref'],  # references to use, shape: (L,)
         f['/A/ref/B/ref_region'], # lookup regions in references, shape: (N,)
-        sel = slice(0,100), # subset of reference region to use
-        as_masked = True    # return a numpy masked array
+        sel = slice(0,100) # subset of reference region to use
         )
     b2a_subset.shape # (100,n)
     b2a_subset.shape[-1] == b2a.shape[-1] # note that n will adaptively scale to what ever is needed to fit the maximum number of references, so this will not always be true!

--- a/README.md
+++ b/README.md
@@ -65,15 +65,93 @@ between datasets are expected to be stored alongside the parent dataset::
 
 with the same dimensions as the parent dataset.
 
-To accomidate null references (which are not well supported by h5py at this time),
-there is a companion boolean dataset `ref_valid` at the corresponding position
-as the `ref` dataset that indicates if the reference is a valid reference. E.g.::
+To accomidate null references and to facilitate fast + parallel read/writes
+there is a companion structured dataset `ref_region` at the corresponding position
+as the `ref` dataset that indicates where to look in the reference dataset for
+the corresponding row. E.g.::
 
     /<dataset0_path>/data
-    /<dataset0_path>/ref/<dataset1_path>/ref # references from dataset0 -> dataset1
-    /<dataset0_path>/ref/<dataset1_path>/ref_valid # indicator for valid dataset0 -> dataset1 reference
-    /<dataset0_path>/ref/<dataset2_path>/ref # references from dataset0 -> dataset2
-    /<dataset0_path>/ref/<dataset2_path>/ref_valid # indicator for valid dataset0 -> dataset2 reference
+    /<dataset0_path>/ref/<dataset1_path>/ref # references from dataset0 -> dataset1 (and back)
+    /<dataset0_path>/ref/<dataset1_path>/ref_region # regions for dataset0 -> dataset1 reference
+    /<dataset0_path>/ref/<dataset2_path>/ref # references from dataset0 -> dataset2 (and back)
+    /<dataset0_path>/ref/<dataset2_path>/ref_region # regions for dataset0 -> dataset2 reference
+
+## example structure
+
+Let's walk through an example in detail. Let's say we have two datasets `A` and
+`B`::
+
+    /A/data
+    /B/data
+
+These must be single dimensional arrays with either a simple or structured type::
+
+    f['/A/data'].dtype # [('id', 'i8'), ('some_val', 'f4')]
+    f['/B/data'].dtype # 'f4'
+
+    f['/A/data'].shape # (N,)
+    f['/B/data'].shape # (M,)
+
+Now, let's say there are references between the two datasets (in particular,
+we've created references from `A->B`::
+
+    /A/ref/B/ref
+    /A/ref/B/ref_region
+    /B/ref/A/ref_region
+
+The `ref` dataset contains indices into the corresponding datasets designated by
+the second dimension. By convention, index 0 is the "parent" dataset (`A`) and index 1
+is the "child" dataset (`B`)::
+
+    f['/A/ref/B/ref'].shape # (L,2)
+    f['/A/ref/B/ref'][:,0] # indices into f['/A/data']
+    f['/A/ref/B/ref'][:,1] # indices into f['/B/data']
+
+    linked_a = f['/A/data'][:][ f['/A/ref/B/ref'][:,0] ] # data from A that can be linked to dataset B (note that you must load the dataset before the fancy indexing can be applied)
+    linked_b = f['/B/data'][:][ f['/A/ref/B/ref'][:,1] ] # data from B that can be linked to dataset A
+    linked_a.shape == linked_b.shape # (L,)
+
+Converting this into a dataset that can be broadcast back into either the `A` or
+`B` shape is facilitated with a helper de-referencing function::
+
+    from h5flow.data import dereference
+
+    b2a = dereference(
+        f['/B/data'],       # dataset to load, shape: (M,)
+        f['/A/ref/B/ref'],  # references to use, shape: (L,)
+        f['/A/ref/B/ref_region'], # lookup regions in references, shape: (N,), special dtype (see below)
+        as_masked = True    # return a numpy masked array
+        )
+    b2a.shape # (N,n), where n is the max number of B items associated with a row in A
+    b2a.dtype == f['/B/data'].dtype # True!
+
+    b_sum = b2a.sum(axis=-1) # use numpy masked array interface to operate on the b2a array
+
+And the inverse relationships can be found by redefining the "ref_direction":::
+
+    a2b = dereference(
+        f['/A/data'],       # dataset to load, shape: (N,)
+        f['/A/ref/B/ref'],  # references to use, shape: (L,)
+        f['/B/ref/A/ref_region'], # lookup regions in references, shape: (M,)
+        ref_direction = (1,0), # now use references from 1->0 (B->A) [default is (0,1)]
+        as_masked = True    # return a numpy masked array
+        )
+    a2b.shape # (M,m), where m is the max number of A items associated with a row in B
+    a2b.dtype == f['/A/data'].dtype # True!
+
+This works just fine - until you start needing to load in very large arrays. In
+that case, you can pass a `sel` slice to select a subset of the parent dataset
+to load, e.g. to load only the first 100 references of A->B::
+
+    b2a_subset = dereference(
+        f['/B/data'],       # dataset to load, shape: (M,)
+        f['/A/ref/B/ref'],  # references to use, shape: (L,)
+        f['/A/ref/B/ref_region'], # lookup regions in references, shape: (N,)
+        sel = slice(0,100), # subset of reference region to use
+        as_masked = True    # return a numpy masked array
+        )
+    b2a_subset.shape # (100,n)
+    b2a_subset.shape[-1] == b2a.shape[-1] # note that n will adaptively scale to what ever is needed to fit the maximum number of references, so this will not always be true!
 
 # h5flow workflow
 

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,11 @@ the need to be familiar with MPI.
 installation
 ------------
 
+First, download this code::
+
+    git clone https://github.com/peter-madigan/h5flow
+    cd h5flow
+
 To setup a fresh conda environment::
 
     conda create --name <env> --file environment.yml

--- a/docs/h5flow/h5flow.data.rst
+++ b/docs/h5flow/h5flow.data.rst
@@ -5,6 +5,10 @@ h5flow.data
    :members:
    :undoc-members:
 
+.. automodule:: h5flow.data.lib
+   :members:
+   :undoc-members:
+
 .. automodule:: h5flow.data.h5flow_data_manager
    :members:
    :undoc-members:

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -3,7 +3,7 @@
 flow:
   source: input # uncomment to use the example generator
   # source: 'input/index' # uncomment to loop over an existing dataset
-  stages: [example_stage0, example_stage1]
+  stages: [example_stage0, example_stage1, print]
   drop: []
 
 input:
@@ -20,7 +20,16 @@ example_stage0:
 example_stage1:
   classname: ExampleStage
   requires:
-      - 'example_stage0/example' # load input/index -> example_stage0/example referred data
+      - 'example_stage0/example' # load simple input/index -> example_stage0/example references
+
+      - name: 'example_stage0/example_idcs' # load indices as well (@example_stage0/example_idcs)
+        path: 'example_stage0/example'
+        index_only: True
+
+      - name: 'input/index_once_referred' # load input -> example_stage0 -> input references
+        path: ['example_stage0/example', 'input/index']
   params:
     output_dset: 'example_stage1/example'
 
+print: # print the contents of the cache if in verbose mode
+  classname: H5FlowTestStage

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -2,15 +2,14 @@
 
 flow:
   source: input # uncomment to use the example generator
-  # source: 'input/random' # uncomment to loop over an existing dataset
+  # source: 'input/index' # uncomment to loop over an existing dataset
   stages: [example_stage0, example_stage1]
   drop: []
 
 input:
   classname: ExampleGenerator
-  dset_name: 'input/random'
+  dset_name: 'input/index'
   params:
-    max_value: 256
     chunk_size: 1024
 
 example_stage0:
@@ -21,7 +20,7 @@ example_stage0:
 example_stage1:
   classname: ExampleStage
   requires:
-      - 'example_stage0/example'
+      - 'example_stage0/example' # load input/index -> example_stage0/example referred data
   params:
     output_dset: 'example_stage1/example'
 

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -4,7 +4,7 @@ flow:
   source: input # uncomment to use the example generator
   # source: 'input/random' # uncomment to loop over an existing dataset
   stages: [example_stage0, example_stage1]
-  drop: ['input/random/data']
+  drop: []
 
 input:
   classname: ExampleGenerator

--- a/h5flow/core/h5_flow_manager.py
+++ b/h5flow/core/h5_flow_manager.py
@@ -142,4 +142,4 @@ class H5FlowManager(object):
                 refs, ref_dir = self.data_manager.get_ref(source_name, linked_name)
                 regions = self.data_manager.get_ref_region(source_name, linked_name)
 
-                cache[linked_name] = dereference(linked_dset, refs, regions, sel=source_slice, ref_direction=ref_dir, as_masked=True)
+                cache[linked_name] = dereference(source_slice, refs, linked_dset, region=regions, ref_direction=ref_dir)

--- a/h5flow/core/h5_flow_manager.py
+++ b/h5flow/core/h5_flow_manager.py
@@ -109,6 +109,7 @@ class H5FlowManager(object):
             tempfile = os.path.join(os.path.dirname(self.data_manager.filepath), '.temp-{}.h5'.format(time.time()))
             subprocess.run(['h5repack', self.data_manager.filepath, tempfile])
             os.replace(tempfile, self.data_manager.filepath)
+            os.remove(tempfile)
         self.comm.barrier()
 
     def update_cache(self, cache, source_name, source_slice, requirements):

--- a/h5flow/core/h5_flow_stage.py
+++ b/h5flow/core/h5_flow_stage.py
@@ -97,30 +97,3 @@ class H5FlowStage(object):
 
         '''
         pass
-
-    def update_cache(self, cache, source_name, source_slice):
-        '''
-            Load and dereference "required" data associated with a given source
-            - first loads the data subset of ``source_name`` specified by the
-            ``source_slice``. Then loops over the datasets in ``self.requires``
-            and loads data from ``source_name -> required_name`` references.
-            Called automatically once per loop, just before calling ``run``.
-
-            Only loads data to the cache if it is not already present
-
-            :param cache: ``dict`` cache to update
-
-            :param source_name: a path to the source dataset group
-
-            :param source_slice: a 1D slice into the source dataset
-
-        '''
-        if source_name not in cache:
-            cache[source_name] = self.data_manager.get_dset(source_name)[source_slice]
-        for linked_name in self.requires:
-            if linked_name not in cache:
-                linked_dset = self.data_manager.get_dset(linked_name)
-                refs = self.data_manager.get_ref(source_name, linked_name)[source_slice]
-                refs_valid = self.data_manager.get_ref_valid(source_name, linked_name)[source_slice]
-                cache[linked_name] = [linked_dset[ref] if valid else np.empty((0,), dtype=linked_dset.dtype) for ref,valid in zip(refs, refs_valid)]
-

--- a/h5flow/data/__init__.py
+++ b/h5flow/data/__init__.py
@@ -1,1 +1,2 @@
+from .lib import *
 from .h5flow_data_manager import *

--- a/h5flow/data/h5flow_data_manager.py
+++ b/h5flow/data/h5flow_data_manager.py
@@ -292,7 +292,7 @@ class H5FlowDataManager(object):
         region = region_dset[sel]
 
         _,idcs,start_idcs = np.intersect1d(np.r_[sel],ref_arr,return_indices=True)
-        start = np.zeros(len(region),dtype='i8')
+        start = np.zeros(len(region), dtype='i8')
         start[idcs] = ref_offset + start_idcs
         region_dset[sel,'start'] = np.where(
             region['start'] != region['stop'],
@@ -301,7 +301,7 @@ class H5FlowDataManager(object):
             )
 
         _,idcs,stop_idcs = np.intersect1d(np.r_[sel],ref_arr[::-1],return_indices=True)
-        stop = np.zeros(len(region),dtype='i8')
+        stop = np.zeros(len(region), dtype='i8')
         stop[idcs] = ref_offset + len(ref_arr) - stop_idcs
         region_dset[sel,'stop'] = np.where(
             region['start'] != region['stop'],

--- a/h5flow/data/h5flow_data_manager.py
+++ b/h5flow/data/h5flow_data_manager.py
@@ -5,6 +5,8 @@ import numpy as np
 from mpi4py import MPI
 import logging
 
+from .lib import ref_region_dtype
+
 class H5FlowDataManager(object):
     '''
         The ``H5FlowDataManager`` class coordinates access to the output data
@@ -98,8 +100,10 @@ class H5FlowDataManager(object):
             :returns: ``True`` if references exists
 
         '''
-        return f'{parent_dataset_name}/ref/{child_dataset_name}/ref' in self.fh \
-            and f'{parent_dataset_name}/ref/{child_dataset_name}/ref_valid' in self.fh
+        return (f'{parent_dataset_name}/ref/{child_dataset_name}/ref' in self.fh \
+                or f'{child_dataset_name}/ref/{parent_dataset_name}/ref' in self.fh) \
+            and f'{parent_dataset_name}/ref/{child_dataset_name}/region' in self.fh \
+            and f'{child_dataset_name}/ref/{parent_dataset_name}/region' in self.fh \
 
     def attr_exists(self, name, key):
         '''
@@ -141,31 +145,34 @@ class H5FlowDataManager(object):
 
     def get_ref(self, parent_dataset_name, child_dataset_name):
         '''
-            Get refrences of ``parent_dataset_name -> child_dataset_name``
+            Get references of ``parent_dataset_name -> child_dataset_name``
 
             :param parent_dataset_name: ``str`` path to parent dataset, e.g. ``stage0/obj0``
 
             :param child_dataset_name: ``str`` path to child dataset, e.g. ``stage0/obj1``
 
-            :returns: ``h5py.Dataset``, e.g. ``stage0/obj0/ref/stage0/obj1/ref``
+            :returns: ``tuple`` of ``h5py.Dataset``, reference direction; e.g. ``(stage0/obj0/ref/stage0/obj1/ref, (0,1))``
 
         '''
-        dset = self.fh[f'{parent_dataset_name}/ref/{child_dataset_name}/ref']
-        return dset
+        if f'{parent_dataset_name}/ref/{child_dataset_name}/ref' in self.fh:
+            dset = self.fh[f'{parent_dataset_name}/ref/{child_dataset_name}/ref']
+            return dset, (0,1)
+        dset = self.fh[f'{child_dataset_name}/ref/{parent_dataset_name}/ref']
+        return dset, (1,0)
 
-    def get_ref_valid(self, parent_dataset_name, child_dataset_name):
+    def get_ref_region(self, parent_dataset_name, child_dataset_name):
         '''
-            Get refrences of ``parent_dataset_name -> child_dataset_name``
+            Get reference lookup regions for ``parent_dataset_name -> child_dataset_name``
 
             :param parent_dataset_name: ``str`` path to parent dataset, e.g. ``stage0/obj0``
 
             :param child_dataset_name: ``str`` path to child dataset, e.g. ``stage0/obj1``
 
-            :returns: ``h5py.Dataset``, e.g. ``stage0/obj0/ref/stage0/obj1/ref_valid``
+            :returns: ``h5py.Dataset``, ``stage0/obj0/ref/stage0/obj1/ref_region``, (0,1)
 
         '''
-        dset = self.fh[f'{parent_dataset_name}/ref/{child_dataset_name}/ref_valid']
-        return dset
+        return self.fh[f'{parent_dataset_name}/ref/{child_dataset_name}/ref_region']
+
 
     def set_attrs(self, name, **attrs):
         '''
@@ -206,17 +213,22 @@ class H5FlowDataManager(object):
             :param child_dataset_name: ``str`` path to child dataset, e.g. ``stage0/obj1``
 
         '''
-        path = f'{parent_dataset_name}/ref/{child_dataset_name}/ref'
+        child_path = f'{child_dataset_name}/ref/{parent_dataset_name}'
+        if child_path + '/ref' in self.fh:
+            raise RuntimeError(f'References for {parent_dataset_name}->{child_dataset_name} already exist under {child_path}')
+        path = f'{parent_dataset_name}/ref/{child_dataset_name}'
         if path not in self.fh:
             if f'{parent_dataset_name}/ref' not in self.fh:
                 self.fh.create_group(f'{parent_dataset_name}/ref')
                 self.fh[f'{parent_dataset_name}/ref'].attrs['parent'] = self.fh[f'{parent_dataset_name}/data'].ref
-            self.fh.create_dataset(path, (0,), maxshape=(None,),
-                dtype=h5py.regionref_dtype)
-            self.fh.create_dataset(path+'_valid', (0,), maxshape=(None,),
-                dtype='u1')
-            self.fh[path].attrs['child'] = self.fh[f'{child_dataset_name}/data'].ref
-            self.fh[path+'_valid'].attrs['child'] = self.fh[f'{child_dataset_name}/data'].ref
+            self.fh.create_dataset(path+'/ref', shape=(0,2), maxshape=(None,2),
+                dtype='u8')
+            self.fh[path+'/ref'].attrs['child'] = self.fh[f'{child_dataset_name}/data'].ref
+            self.fh.create_dataset(path+'/ref_region', shape=(0,), maxshape=(None,),
+                dtype=ref_region_dtype, fillvalue=np.zeros((1,), dtype=ref_region_dtype))
+            if (child_path+'/ref_region') not in self.fh:
+                self.fh.create_dataset(child_path+'/ref_region', shape=(0,), maxshape=(None,),
+                    dtype=ref_region_dtype, fillvalue=np.zeros((1,), dtype=ref_region_dtype))
 
     def reserve_data(self, dataset_name, spec):
         '''
@@ -233,18 +245,28 @@ class H5FlowDataManager(object):
             :returns: ``slice`` into ``dataset_name`` where access is given
 
         '''
+        grp = self.fh[dataset_name]
         dset = self.get_dset(dataset_name)
         curr_len = len(dset)
         specs = self.comm.allgather(spec)
         if isinstance(spec, int):
             # create a new chunk at the end of the dataset
-            dset.resize((curr_len + sum(specs),))
+            n = sum(specs)
+            grp.visititems(
+                lambda name,d : d.resize((curr_len + n,)) \
+                if (name.endswith('data') or name.endswith('ref_region')) and isinstance(d, h5py.Dataset)\
+                else None
+                )
             rv = slice(curr_len + sum(specs[:self.rank]), curr_len + sum(specs[:self.rank+1]))
         elif isinstance(spec, slice):
             # maybe create up to a specific chunk of the dataset
             new_size = max([spec.stop for spec in specs])
             if new_size > curr_len:
-                dset.resize((new_size,))
+                grp.visititems(
+                    lambda name,d : d.resize((new_size,)) \
+                    if (name.endswith('data') or name.endswith('ref_region')) and isinstance(d, h5py.Dataset)\
+                    else None
+                )
             rv = spec
         else:
             raise TypeError(f'spec {spec} is not a valid type')
@@ -265,163 +287,49 @@ class H5FlowDataManager(object):
         dset[spec] = data
 
     @staticmethod
-    def merge_region_specs(*specs):
+    def _update_ref_region(region_dset, sel, ref_arr, ref_offset):
+        # Note:: ref_arr is the 1D array of indices into region_dset to update, ref_offset is where ref_array is positioned within a larger ref dataset
+        region = region_dset[sel]
+
+        _,idcs,start_idcs = np.intersect1d(np.r_[sel],ref_arr,return_indices=True)
+        start = np.zeros(len(region),dtype='i8')
+        start[idcs] = ref_offset + start_idcs
+        region_dset[sel,'start'] = np.where(
+            region['start'] != region['stop'],
+            np.minimum(region['start'], start),
+            start
+            )
+
+        _,idcs,stop_idcs = np.intersect1d(np.r_[sel],ref_arr[::-1],return_indices=True)
+        stop = np.zeros(len(region),dtype='i8')
+        stop[idcs] = ref_offset + len(ref_arr) - stop_idcs
+        region_dset[sel,'stop'] = np.where(
+            region['start'] != region['stop'],
+            np.maximum(region['stop'], stop),
+            stop
+            )
+
+    def write_ref(self, parent_dataset_name, child_dataset_name, refs):
         '''
-            Join a region specification into one of:
-             - a slice
-             - an array of integers (shape: (N, 1))
+            Add refs for ``parent_dataset_name -> child_dataset_name``. Note
+            that references are never updated and can't be removed after they
+            are created.
 
-            Follows the ``numpy.c_[...]`` behavior except prunes for unique values
-            and sorts. If indices can be simplified into a ``slice`` selection,
-            this method returns a slice. E.g.::
-
-                merge_region_specs(slice(0,10), slice(10,20)) # returns slice(0,20,1)
-                merge_region_specs(0,[1,2],3) # returns slice(0,4,1)
-                merge_region_specs(slice(0,4,2),[2,4,6],8,2) # returns slice(0,10,2)
-                merge_region_specs(slice(0,5),10) # returns np.array([0,1,2,3,4,10])
-
-            Note that empty iterables or empty slices produce empty slices::
-
-                merge_region_specs([], slice(0,0,1)) # returns slice(0,0,1)
-
-            :param specs: a collection of ``int``, ``slice``, iterable of ``int``, or iterable of ``slice`` to join
-
-        '''
-        flat_specs = []
-        for s in specs:
-            if isinstance(s,np.integer) or isinstance(s,int) or isinstance(s,slice):
-                flat_specs.append(s)
-            else:
-                flat_specs.extend(s)
-
-        if len(flat_specs) > 1:
-            idcs = np.sort(np.unique(np.r_[(*flat_specs,)].astype(int)))
-        elif len(flat_specs):
-            idcs = np.sort(np.unique(np.r_[flat_specs[0]].astype(int)))
-        else:
-            return np.empty((0,1), dtype=int)
-
-        if len(idcs) == 0:
-            # refers to no region => default to empty slice behavior
-            return np.empty((0,1), dtype=int)
-        elif len(idcs) <= 2:
-            # only a few => return array
-            return idcs[:,np.newaxis]
-
-        step = np.diff(idcs, axis=0)
-        if np.all(np.abs(step) == step[0]):
-            # can be reduced to a simple slice
-            return slice(idcs[0],idcs[-1]+step[0],step[0])
-        return idcs[:,np.newaxis]
-
-    @staticmethod
-    def create_ref_array(dset, spec):
-        array = np.empty((len(spec),), dtype=h5py.regionref_dtype)
-        space = h5s.create_simple(dset.id.shape)
-        for i in range(len(spec)):
-            item = spec[i]
-            if isinstance(item, slice):
-                start = item.start if item.start is not None else 0
-                stride = item.step if item.step is not None else 1
-                count = (item.stop-start)//stride if item.stop is not None else (dset.shape[0]-start)//stride
-                if count == 0:
-                    continue
-                space.select_hyperslab((start,), (count,), (stride,))
-            elif isinstance(item,int) or isinstance(item,np.integer):
-                space.select_hyperslab((item,), (1,))
-            elif len(item) == 0:
-                continue
-            else:
-                space.select_elements(item)
-            array[i] = h5r.create(dset.id, b'.', h5r.DATASET_REGION, space)
-        return array
-
-    def reserve_ref(self, parent_dataset_name, child_dataset_name, spec):
-        '''
-            Coordinate access into ``parent_dataset_name -> child_dataset_name``
-            references. Depending on the type of
-            ``spec`` a different access mode will be performed:
-
-                - ``int``: access in append mode - will grant access to ``spec`` rows at the end of the dataset
-                - ``slice`` or iterable of ``int`` or iterable of ``slice``: access a specific section - will resize dataset if section does not exist
-
-            Note: access pattern (append or selection) must be the same in all processes
-
-            :param parent_dataset_name: ``str`` path to dataset, e.g. ``stage0/obj0``
-
-            :param child_dataset_name: ``str`` path to dataset, e.g. ``stage0/obj0``
-
-            :param spec: see function description
-
-            :returns: ``slice`` into ``parent_dataset_name/ref/child_dataset_name`` where access is given
+            :param refs: an integer array of shape (N,2) with refs[:,0] corresponding to the index in the parent dataset and refs[:,1] corresponding to the index in the child dataset
 
         '''
-        dset = self.get_ref(parent_dataset_name, child_dataset_name)
-        dset_valid = self.get_ref_valid(parent_dataset_name, child_dataset_name)
-        curr_len = len(dset)
-        if isinstance(spec, slice):
-            all_specs = self.comm.allgather([spec])
-        else:
-            all_specs = self.comm.allgather(spec)
-        if isinstance(spec, int):
-            # create a new chunk at the end of the dataset
-            dset.resize((curr_len + sum(all_specs),))
-            dset_valid.resize((curr_len + sum(all_specs),))
-            rv = slice(curr_len + sum(all_specs[:self.rank]), curr_len + sum(all_specs[:self.rank+1]))
-        else:
-            try:
-                # maybe create up to a specific chunk of the dataset
-                idcs = np.r_[self.merge_region_specs(*[s for ss in all_specs for s in ss])]+1
-                if len(idcs):
-                    new_size = np.max(idcs)
-                    if new_size > curr_len:
-                        dset.resize((new_size,))
-                        dset_valid.resize((new_size,))
-                rv = spec
-            except TypeError:
-                raise TypeError(f'spec {spec} is not a valid specification')
-        return rv
+        ns = self.comm.allgather(len(refs))
 
-    def write_ref(self, parent_dataset_name, child_dataset_name, spec, refs):
-        '''
-            Write refs into ``parent_dataset_name -> child_dataset_name`` at
-            ``spec``. As an example of the usage, to write two references
-            referring to the 0 position and the first 10 of ``stage0/obj1``,
-            respectively, one would call::
+        ref_dset, ref_dir = self.get_ref(parent_dataset_name, child_dataset_name)
+        ref_offset = len(ref_dset) + sum(ns[:self.rank])
+        ref_dset.resize((len(ref_dset) + sum(ns), 2))
+        ref_dset[ref_offset:ref_offset + ns[self.rank]] = refs[:,ref_dir]
 
-                hfdm.write_ref('stage0/obj0', 'stage0/obj1', slice(0,2), [0, slice(0,10)])
+        parent_ref_region_dset = self.get_ref_region(parent_dataset_name, child_dataset_name)
+        child_ref_region_dset = self.get_ref_region(child_dataset_name, parent_dataset_name)
 
-            :param parent_dataset_name: ``str`` path to dataset, e.g. ``stage0/obj0``
+        parent_sel = slice(np.min(refs[:,0]), np.max(refs[:,0])+1)
+        child_sel = slice(np.min(refs[:,1]), np.max(refs[:,1])+1)
 
-            :param child_dataset_name: ``str`` path to dataset, e.g. ``stage0/obj1``
-
-            :param spec: ``slice`` into ``parent_dataset_name/ref/child_dataset_name`` to write ``refs``
-
-            :param refs: an iterable with same length specified by ``spec`` of selections into the child dataset
-
-        '''
-        self.close_file()
-        self.comm.barrier()
-
-        clean_ref = [r if isinstance(r,slice) or isinstance(r,int) or isinstance(r,np.integer) \
-            else self.merge_region_specs(*r) for r in refs]
-        valid = np.array([isinstance(r,int) or isinstance(r,np.integer) or (isinstance(r,slice) and r.start != r.stop) or (not isinstance(r,slice) and len(r) > 0) for r in clean_ref], dtype=bool)
-
-        if self.rank == 0:
-            self._open_file(mpi=False)
-            dset = self.get_ref(parent_dataset_name, child_dataset_name)
-            dset_valid = self.get_ref_valid(parent_dataset_name, child_dataset_name)
-            child_dset = self.get_dset(child_dataset_name)
-
-            for r in range(self.size):
-                if r != self.rank:
-                    spec, clean_ref, valid = self.comm.recv(source=r)
-
-                dset[spec] = self.create_ref_array(child_dset, clean_ref)# np.array([child_dset.regionref[r] for r in clean_ref], dtype=h5py.regionref_dtype)
-                dset_valid[spec] = valid
-
-            self.close_file()
-            self.comm.barrier()
-        else:
-            self.comm.send((spec, clean_ref, valid), dest=0)
-            self.comm.barrier()
+        self._update_ref_region(parent_ref_region_dset, parent_sel, refs[:,0], ref_offset)
+        self._update_ref_region(child_ref_region_dset, child_sel, refs[:,1], ref_offset)

--- a/h5flow/data/h5flow_data_manager.py
+++ b/h5flow/data/h5flow_data_manager.py
@@ -325,11 +325,12 @@ class H5FlowDataManager(object):
         ref_dset.resize((len(ref_dset) + sum(ns), 2))
         ref_dset[ref_offset:ref_offset + ns[self.rank]] = refs[:,ref_dir]
 
-        parent_ref_region_dset = self.get_ref_region(parent_dataset_name, child_dataset_name)
-        child_ref_region_dset = self.get_ref_region(child_dataset_name, parent_dataset_name)
+        if len(refs):
+            parent_ref_region_dset = self.get_ref_region(parent_dataset_name, child_dataset_name)
+            child_ref_region_dset = self.get_ref_region(child_dataset_name, parent_dataset_name)
 
-        parent_sel = slice(np.min(refs[:,0]), np.max(refs[:,0])+1)
-        child_sel = slice(np.min(refs[:,1]), np.max(refs[:,1])+1)
+            parent_sel = slice(np.min(refs[:,0]), np.max(refs[:,0])+1)
+            child_sel = slice(np.min(refs[:,1]), np.max(refs[:,1])+1)
 
-        self._update_ref_region(parent_ref_region_dset, parent_sel, refs[:,0], ref_offset)
-        self._update_ref_region(child_ref_region_dset, child_sel, refs[:,1], ref_offset)
+            self._update_ref_region(parent_ref_region_dset, parent_sel, refs[:,0], ref_offset)
+            self._update_ref_region(child_ref_region_dset, child_sel, refs[:,1], ref_offset)

--- a/h5flow/data/lib.py
+++ b/h5flow/data/lib.py
@@ -1,34 +1,43 @@
+import h5py
 import numpy as np
 import numpy.ma as ma
 
 ref_region_dtype = np.dtype([('start','i8'), ('stop','i8')])
 
-def dereference(data, ref, region, sel=None, ref_direction=(0,1), as_masked=True):
+def dereference(sel, ref, data, region=None, ref_direction=(0,1), indices_only=False, as_masked=True):
     '''
         Load ``data`` referred to by ``ref`` that corresponds to the desired
-        positions within the ``region`` lookup table.
+        positions specified in ``sel``.
+
+        :param sel: iterable of indices, an index, or a ``slice`` to match against ``ref[:,ref_direction[0]]``. Return value will have same first dimension as ``sel``, e.g. ``dereference(slice(100), ref, data).shape[0] == 100``
+
+        :param ref: a shape (N,2) ``h5py.Dataset`` or array of pairs of indices linking ``sel`` and ``data``
 
         :param data: a ``h5py.Dataset`` or array to load dereferenced data from
 
-        :param ref: a shape (N,2) ``h5py.Dataset`` or array of pairs of indices linking ``region`` and ``data``
+        :param region: a 1D ``h5py.Dataset`` or array with a structured array type of [('start','i8'), ('stop','i8')]; 'start' defines the earliest index within the ``ref`` dataset for each value in ``sel``, and 'stop' defines the last index + 1 within the ``ref`` dataset (optional). If a ``h5py.Dataset`` is used, the ``sel`` spec will be used to load data from the dataset (i.e. ``region[sel]``), otherwise ``len(sel) == len(region)`` and a 1:1 correspondence is assumed
 
-        :param region: a 1D ``h5py.Dataset`` or array with a structured array type of [('start','i8'), ('stop','i8')]; 'start' defines the earliest index within the ``ref`` dataset, 'stop' defines the last index + 1 within the ``ref`` dataset
+        :param ref_direction: defines how to interpret second dimension of ``ref``. ``ref[:,ref_direction[0]]`` are matched against items in ``sel``, and ``ref[:,ref_direction[1]]`` are indices into the ``data`` array (``default=(0,1)``). So for a simple example: ``dereference([0,1,2], [[1,0], [2,1]], ['A','B','C','D'], ref_direction=(0,1))`` returns an array equivalent to ``[[],['A'],['B']]`` and ``dereference([0,1,2], [[1,0], [2,1]], ['A','B','C','D'], ref_direction=(1,0))`` returns an array equivalent to ``[['B'],['C'],[]]``
 
-        :param sel: iterable of indices, an index, or a `slice` into a subset of the ``region`` dataset to load (optional)
+        :param indices_only: if ``True``, only returns the indices into ``data``, does not fetch data from ``data``
 
-        :param ref_direction: defines how to interpret second dimension of ``ref``. ``ref[:,ref_direction[0]]`` should produce indices into the ``region`` array, and ``ref[:,ref_direction[1]]`` should produce indices into the ``data`` array (``default=(0,1)``)
-
-        :returns: ``numpy`` masked array, or (if ``as_masked=False``) ``list`` of length equivalent to ``sel``
+        :returns: ``numpy`` masked array (or if ``as_masked=False`` a ``list``) of length equivalent to ``sel``
     '''
-    if sel is not None:
-        region = region[sel] # load parent reference region information
-    else:
-        region = region[:]
-        sel = slice(0,len(region))
     sel_idcs = np.r_[sel]
+    if region is not None:
+        if isinstance(region, h5py.Dataset):
+            if isinstance(sel, slice):
+                region = region[sel] # load parent reference region information
+            else:
+                region_offset = np.min(sel_idcs)
+                region_sel = slice(region_offset, int(np.max(sel_idcs)+1))
+                region = region[region_sel][sel_idcs - region_offset]
+        else:
+            region = region[sel_idcs]
 
-    ref_offset = np.min(region['start'])
-    ref_sel = slice(ref_offset, int(np.max(region['stop'])))
+    region_valid = region['start'] != region['stop'] if region is not None else None
+    ref_offset = np.min(region[region_valid]['start']) if region is not None else 0
+    ref_sel = slice(ref_offset, int(np.max(region[region_valid]['stop']))) if region is not None else slice(ref_offset,len(ref))
     ref = ref[ref_sel] # load reference region
 
     dset_offset = np.min(ref[:,ref_direction[1]])
@@ -36,25 +45,56 @@ def dereference(data, ref, region, sel=None, ref_direction=(0,1), as_masked=True
     dset = data[dset_sel] # load child dataset region
 
     if not as_masked:
+        if region is None:
+            region = np.zeros(len(sel_idcs), dtype=ref_region_dtype)
+            region['start'] = ref_sel.start
+            region['stop'] = ref_sel.stop
+
         # dump into list using subregion masks
-        data = [
-                dset[ref[st:sp,ref_direction[1]][ (ref[st:sp,ref_direction[0]] == i) ] - dset_offset]
-                for i,st,sp in zip(sel_idcs, region['start']-ref_offset, region['stop']-ref_offset)
-            ]
-        return data
+        if indices_only:
+            indices = [
+                    ref[st:sp,ref_direction[1]][ (ref[st:sp,ref_direction[0]] == i) ]
+                    for i,st,sp in zip(sel_idcs, region['start']-ref_offset, region['stop']-ref_offset)
+                ]
+            return indices
+        else:
+            data = [
+                    dset[ref[st:sp,ref_direction[1]][ (ref[st:sp,ref_direction[0]] == i) ] - dset_offset]
+                    for i,st,sp in zip(sel_idcs, region['start']-ref_offset, region['stop']-ref_offset)
+                ]
+            return data
 
     ref_mask = np.isin(ref[:,ref_direction[0]], sel_idcs) # only use relevant references
 
     uniq, counts = np.unique(ref[ref_mask,ref_direction[0]], return_counts=True) # get number of references per parent
-    _,region_idcs,uniq_idcs = np.intersect1d(sel_idcs, uniq, assume_unique=True, return_indices=True) # map parent -> number of ref
+    reordering = np.argsort(uniq) # sort references by parent index (used for filling the correct slots)
+    uniq, counts = uniq[reordering], counts[reordering]
+    max_counts = np.max(counts)
 
-    data = np.empty((len(sel_idcs), np.max(counts)), dtype=dset.dtype) # prep output array
-    mask = np.zeros(data.shape, dtype=bool)
+    # first fill a subarray consisting of unique elements that were requested (shape: (len(uniq_sel), max_counts) )
+    uniq_sel, uniq_inv = np.unique(sel_idcs, return_inverse=True) # get mapping from unique reference parent -> selection index
+    _,uniq_sel_idcs,uniq2uniq_sel_idcs = np.intersect1d(uniq_sel, uniq, assume_unique=False, return_indices=True) # map unique selection parent -> unique reference parent
 
-    mask[region_idcs] = np.arange(data.shape[-1]).reshape(1,-1) < counts[uniq_idcs].reshape(-1,1) # make n slots available per parent
+    # set up arrays for unique selection parents
+    shape = (len(uniq_sel), max_counts) + dset.shape[1:]
+    condensed_data = np.zeros(shape, dtype=dset.dtype) if not indices_only \
+        else np.zeros(shape, dtype=ref.dtype)
+    condensed_mask = np.zeros(shape, dtype=bool)
 
-    sort_ref = np.argsort(ref[ref_mask,ref_direction[0]]) # arrange by parent index
-    np.place(data, mask=mask, vals=dset[ref[ref_mask,ref_direction[1]][sort_ref] - dset_offset]) # fill slots
+    # block off and fill slots for unique selection
+    condensed_mask[uniq_sel_idcs] = np.arange(condensed_data.shape[1]).reshape(1,-1) < counts[uniq2uniq_sel_idcs].reshape(-1,1)
+    view_dtype = np.dtype([('f0',ref.dtype),('f1',ref.dtype)])
+    sort_ref = np.argsort(ref[ref_mask].view(view_dtype), axis=0,
+        order=[view_dtype.names[ref_direction[0]], view_dtype.names[ref_direction[1]]]
+        ) # arrange by parent (then by child)
+    # fill slots
+    if indices_only:
+        np.place(condensed_data, mask=condensed_mask, vals=ref[ref_mask,ref_direction[1]][sort_ref])
+    else:
+        np.place(condensed_data, mask=condensed_mask, vals=dset[ref[ref_mask,ref_direction[1]][sort_ref] - dset_offset])
 
+    # then cast unique selections into full set of elements that were requested (shape: (len(sel), max_counts) )
+    mask = condensed_mask[uniq_inv]
+    data = condensed_data[uniq_inv]
     return ma.array(data, mask=~mask)
 

--- a/h5flow/data/lib.py
+++ b/h5flow/data/lib.py
@@ -1,10 +1,38 @@
 import h5py
 import numpy as np
 import numpy.ma as ma
+import logging
 
 ref_region_dtype = np.dtype([('start','i8'), ('stop','i8')])
 
-def dereference(sel, ref, data, region=None, ref_direction=(0,1), indices_only=False, as_masked=True):
+def print_ref(grp):
+    '''
+        Print out all references in file (or group)
+    '''
+    l = list()
+    grp.visititems(lambda n,d: l.append((n,d))\
+        if n.endswith('/ref') and isinstance(d,h5py.Dataset)
+        else None
+        )
+    max_length = max([len(n) for n,d in l])
+    for n,d in l:
+        print(n+' '*(max_length-len(n))+' '+str(d))
+
+def print_data(grp):
+    '''
+        Print out all datasets in file (or group)
+
+    '''
+    l = list()
+    grp.visititems(lambda n,d: l.append((n,d))\
+        if n.endswith('/data') and isinstance(d,h5py.Dataset)
+        else None
+        )
+    max_length = max([len(n) for n,d in l])
+    for n,d in l:
+        print(n+' '*(max_length-len(n))+' '+str(d))
+
+def dereference(sel, ref, data, region=None, mask=None, ref_direction=(0,1), indices_only=False, as_masked=True):
     '''
         Load ``data`` referred to by ``ref`` that corresponds to the desired
         positions specified in ``sel``.
@@ -17,13 +45,32 @@ def dereference(sel, ref, data, region=None, ref_direction=(0,1), indices_only=F
 
         :param region: a 1D ``h5py.Dataset`` or array with a structured array type of [('start','i8'), ('stop','i8')]; 'start' defines the earliest index within the ``ref`` dataset for each value in ``sel``, and 'stop' defines the last index + 1 within the ``ref`` dataset (optional). If a ``h5py.Dataset`` is used, the ``sel`` spec will be used to load data from the dataset (i.e. ``region[sel]``), otherwise ``len(sel) == len(region)`` and a 1:1 correspondence is assumed
 
+        :param mask: mask off specific items in selection (boolean, True == don't dereference selection), len(mask) == len(np.r_[sel])
+
         :param ref_direction: defines how to interpret second dimension of ``ref``. ``ref[:,ref_direction[0]]`` are matched against items in ``sel``, and ``ref[:,ref_direction[1]]`` are indices into the ``data`` array (``default=(0,1)``). So for a simple example: ``dereference([0,1,2], [[1,0], [2,1]], ['A','B','C','D'], ref_direction=(0,1))`` returns an array equivalent to ``[[],['A'],['B']]`` and ``dereference([0,1,2], [[1,0], [2,1]], ['A','B','C','D'], ref_direction=(1,0))`` returns an array equivalent to ``[['B'],['C'],[]]``
 
         :param indices_only: if ``True``, only returns the indices into ``data``, does not fetch data from ``data``
 
         :returns: ``numpy`` masked array (or if ``as_masked=False`` a ``list``) of length equivalent to ``sel``
     '''
-    sel_idcs = np.r_[sel]
+    # set up selection
+    sel_mask = mask
+    sel_idcs = np.r_[sel][~sel_mask] if sel_mask is not None else np.r_[sel]
+    n_elem = len(sel_idcs) if sel_mask is None else len(sel_mask)
+
+    if not len(sel_idcs) and n_elem:
+        # special case for if there is nothing selected in the mask
+        if as_masked:
+            return ma.array(np.empty((n_elem,1), dtype=data.dtype), mask=True)
+        else:
+            return [np.empty(0, data.dtype) for _ in range(n_elem)]
+    elif not len(sel_idcs):
+        if as_masked:
+            return ma.array(np.empty((0,1), dtype=data.dtype), mask=True)
+        else:
+            return []
+
+    # load fast region lookup
     if region is not None:
         if isinstance(region, h5py.Dataset):
             if isinstance(sel, slice):
@@ -35,21 +82,29 @@ def dereference(sel, ref, data, region=None, ref_direction=(0,1), indices_only=F
         else:
             region = region[sel_idcs]
 
+    # load relevant references
     region_valid = region['start'] != region['stop'] if region is not None else None
+    if not region is None and np.count_nonzero(region_valid) == 0:
+        # special case for if there are no valid references
+        if as_masked:
+            return ma.array(np.empty((n_elem,1), dtype=data.dtype), mask=True)
+        else:
+            return [np.empty(0, data.dtype) for _ in range(n_elem)]
     ref_offset = np.min(region[region_valid]['start']) if region is not None else 0
     ref_sel = slice(ref_offset, int(np.max(region[region_valid]['stop']))) if region is not None else slice(ref_offset,len(ref))
+
     ref = ref[ref_sel] # load reference region
 
     dset_offset = np.min(ref[:,ref_direction[1]])
     dset_sel = slice(dset_offset, int(np.max(ref[:,ref_direction[1]])+1))
     dset = data[dset_sel] # load child dataset region
 
-    if not as_masked:
-        if region is None:
-            region = np.zeros(len(sel_idcs), dtype=ref_region_dtype)
-            region['start'] = ref_sel.start
-            region['stop'] = ref_sel.stop
+    if region is None:
+        region = np.zeros(len(sel_idcs), dtype=ref_region_dtype)
+        region['start'] = ref_sel.start
+        region['stop'] = ref_sel.stop
 
+    if not as_masked:
         # dump into list using subregion masks
         if indices_only:
             indices = [
@@ -83,7 +138,7 @@ def dereference(sel, ref, data, region=None, ref_direction=(0,1), indices_only=F
 
     # block off and fill slots for unique selection
     condensed_mask[uniq_sel_idcs] = np.arange(condensed_data.shape[1]).reshape(1,-1) < counts[uniq2uniq_sel_idcs].reshape(-1,1)
-    view_dtype = np.dtype([('f0',ref.dtype),('f1',ref.dtype)])
+    view_dtype = np.dtype([('ref0',ref.dtype),('ref1',ref.dtype)])
     sort_ref = np.argsort(ref[ref_mask].view(view_dtype), axis=0,
         order=[view_dtype.names[ref_direction[0]], view_dtype.names[ref_direction[1]]]
         ) # arrange by parent (then by child)
@@ -94,7 +149,12 @@ def dereference(sel, ref, data, region=None, ref_direction=(0,1), indices_only=F
         np.place(condensed_data, mask=condensed_mask, vals=dset[ref[ref_mask,ref_direction[1]][sort_ref] - dset_offset])
 
     # then cast unique selections into full set of elements that were requested (shape: (len(sel), max_counts) )
-    mask = condensed_mask[uniq_inv]
-    data = condensed_data[uniq_inv]
+    mask = np.zeros((len(sel_mask), max_counts), dtype=bool) if sel_mask is not None \
+        else condensed_mask[uniq_inv]
+    data = np.zeros((len(sel_mask), max_counts), dtype=condensed_data.dtype) if sel_mask is not None \
+        else condensed_data[uniq_inv]
+    if sel_mask is not None:
+        mask[~sel_mask] = condensed_mask[uniq_inv]
+        data[~sel_mask] = condensed_data[uniq_inv]
     return ma.array(data, mask=~mask)
 

--- a/h5flow/data/lib.py
+++ b/h5flow/data/lib.py
@@ -3,29 +3,29 @@ import numpy.ma as ma
 
 ref_region_dtype = np.dtype([('start','i8'), ('stop','i8')])
 
-def dereference(data, ref, region, sel=None, ref_direction=(0,1), as_masked=False):
+def dereference(data, ref, region, sel=None, ref_direction=(0,1), as_masked=True):
     '''
         Load ``data`` referred to by ``ref`` that corresponds to the desired
         positions within the ``region`` lookup table.
 
         :param data: a ``h5py.Dataset`` or array to load dereferenced data from
 
-        :param ref: a shape (N,2) ``h5py.Dataset`` or array of pairs of indices into first dimension of ``data``
+        :param ref: a shape (N,2) ``h5py.Dataset`` or array of pairs of indices linking ``region`` and ``data``
 
         :param region: a 1D ``h5py.Dataset`` or array with a structured array type of [('start','i8'), ('stop','i8')]; 'start' defines the earliest index within the ``ref`` dataset, 'stop' defines the last index + 1 within the ``ref`` dataset
 
         :param sel: iterable of indices, an index, or a `slice` into a subset of the ``region`` dataset to load (optional)
 
-        :param ref_direction: defines how indices in the second dimension of ``ref`` are treated. ``ref_direction[0]`` corresponds to the index in ``ref`` that points to
-        ``ref[:,0]``, else load data corresponding to ``ref[:,1]``
+        :param ref_direction: defines how to interpret second dimension of ``ref``. ``ref[:,ref_direction[0]]`` should produce indices into the ``region`` array, and ``ref[:,ref_direction[1]]`` should produce indices into the ``data`` array (``default=(0,1)``)
 
-        :returns: `list` of length equal to the spec, or ``numpy`` masked array (if ``as_masked==True``)
+        :returns: ``numpy`` masked array, or (if ``as_masked=False``) ``list`` of length equivalent to ``sel``
     '''
     if sel is not None:
-        region = region[sel] # load reference region information
+        region = region[sel] # load parent reference region information
     else:
         region = region[:]
         sel = slice(0,len(region))
+    sel_idcs = np.r_[sel]
 
     ref_offset = np.min(region['start'])
     ref_sel = slice(ref_offset, int(np.max(region['stop'])))
@@ -35,20 +35,26 @@ def dereference(data, ref, region, sel=None, ref_direction=(0,1), as_masked=Fals
     dset_sel = slice(dset_offset, int(np.max(ref[:,ref_direction[1]])+1))
     dset = data[dset_sel] # load child dataset region
 
-    data = [
-            dset[ref[st:sp,ref_direction[1]][ (ref[st:sp,ref_direction[0]] == i) ] - dset_offset]
-            for i,st,sp in zip(np.r_[sel], region['start']-ref_offset, region['stop']-ref_offset)
-        ]
     if not as_masked:
+        # dump into list using subregion masks
+        data = [
+                dset[ref[st:sp,ref_direction[1]][ (ref[st:sp,ref_direction[0]] == i) ] - dset_offset]
+                for i,st,sp in zip(sel_idcs, region['start']-ref_offset, region['stop']-ref_offset)
+            ]
         return data
 
-    if len(data) == 0:
-        return ma.empty((0,0), dtype=dset.dtype)
-    max_ref = np.max([len(d) for d in data])
-    masked_data = ma.empty((len(region),max_ref), dtype=dset.dtype)
-    masked_data.mask = True
-    for i,d in enumerate(data):
-        n = len(d)
-        masked_data[i,0:n] = d
-        masked_data.mask[i,0:n] = False
-    return masked_data
+    ref_mask = np.isin(ref[:,ref_direction[0]], sel_idcs) # only use relevant references
+
+    uniq, counts = np.unique(ref[ref_mask,ref_direction[0]], return_counts=True) # get number of references per parent
+    _,region_idcs,uniq_idcs = np.intersect1d(sel_idcs, uniq, assume_unique=True, return_indices=True) # map parent -> number of ref
+
+    data = np.empty((len(sel_idcs), np.max(counts)), dtype=dset.dtype) # prep output array
+    mask = np.zeros(data.shape, dtype=bool)
+
+    mask[region_idcs] = np.arange(data.shape[-1]).reshape(1,-1) < counts[uniq_idcs].reshape(-1,1) # make n slots available per parent
+
+    sort_ref = np.argsort(ref[ref_mask,ref_direction[0]]) # arrange by parent index
+    np.place(data, mask=mask, vals=dset[ref[ref_mask,ref_direction[1]][sort_ref] - dset_offset]) # fill slots
+
+    return ma.array(data, mask=~mask)
+

--- a/h5flow/data/lib.py
+++ b/h5flow/data/lib.py
@@ -1,0 +1,54 @@
+import numpy as np
+import numpy.ma as ma
+
+ref_region_dtype = np.dtype([('start','i8'), ('stop','i8')])
+
+def dereference(data, ref, region, sel=None, ref_direction=(0,1), as_masked=False):
+    '''
+        Load ``data`` referred to by ``ref`` that corresponds to the desired
+        positions within the ``region`` lookup table.
+
+        :param data: a ``h5py.Dataset`` or array to load dereferenced data from
+
+        :param ref: a shape (N,2) ``h5py.Dataset`` or array of pairs of indices into first dimension of ``data``
+
+        :param region: a 1D ``h5py.Dataset`` or array with a structured array type of [('start','i8'), ('stop','i8')]; 'start' defines the earliest index within the ``ref`` dataset, 'stop' defines the last index + 1 within the ``ref`` dataset
+
+        :param sel: iterable of indices, an index, or a `slice` into a subset of the ``region`` dataset to load (optional)
+
+        :param ref_direction: defines how indices in the second dimension of ``ref`` are treated. ``ref_direction[0]`` corresponds to the index in ``ref`` that points to
+        ``ref[:,0]``, else load data corresponding to ``ref[:,1]``
+
+        :returns: `list` of length equal to the spec, or ``numpy`` masked array (if ``as_masked==True``)
+    '''
+    if sel is not None:
+        region = region[sel] # load reference region information
+    else:
+        region = region[:]
+        sel = slice(0,len(region))
+
+    ref_offset = np.min(region['start'])
+    ref_sel = slice(ref_offset, int(np.max(region['stop'])))
+    ref = ref[ref_sel] # load reference region
+
+    dset_offset = np.min(ref[:,ref_direction[1]])
+    dset_sel = slice(dset_offset, int(np.max(ref[:,ref_direction[1]])+1))
+    dset = data[dset_sel] # load child dataset region
+
+    data = [
+            dset[ref[st:sp,ref_direction[1]][ (ref[st:sp,ref_direction[0]] == i) ] - dset_offset]
+            for i,st,sp in zip(np.r_[sel], region['start']-ref_offset, region['stop']-ref_offset)
+        ]
+    if not as_masked:
+        return data
+
+    if len(data) == 0:
+        return ma.empty((0,0), dtype=dset.dtype)
+    max_ref = np.max([len(d) for d in data])
+    masked_data = ma.empty((len(region),max_ref), dtype=dset.dtype)
+    masked_data.mask = True
+    for i,d in enumerate(data):
+        n = len(d)
+        masked_data[i,0:n] = d
+        masked_data.mask[i,0:n] = False
+    return masked_data

--- a/h5flow/modules/h5_flow_dataset_loop_generator.py
+++ b/h5flow/modules/h5_flow_dataset_loop_generator.py
@@ -75,10 +75,8 @@ class H5FlowDatasetLoopGenerator(H5FlowGenerator):
         if self.chunk_size == 'auto':
             # in auto mode, use the default chunk size in the hdf5 file
             self.chunk_size = dset.chunks[0]
-            # sel = slice(self.start_position, self.end_position)
-            # self.slices = [sl[0] for sl in dset.iter_chunks(sel=sel)][self.rank::self.size]
 
-        # in manual mode, each process grabs `chunk_size` chunks from the file
+        # in manual mode, each process grabs `chunk_size` rows from the file
         start = self.rank * self.chunk_size + self.start_position
         end = self.end_position
         r = range(start, end, self.size * self.chunk_size)

--- a/h5flow/modules/h5_flow_test_stage.py
+++ b/h5flow/modules/h5_flow_test_stage.py
@@ -30,9 +30,9 @@ class H5FlowTestStage(H5FlowStage):
     def run(self, source_name, source_slice, cache):
         logging.info(f'source_name: {source_name}')
         logging.info(f'source_slice: {source_slice}')
-        logging.info('cache item lengths:')
+        logging.info('cache items:')
         for key,val in cache.items():
-            logging.info(f'\t{key}: {len(val)}')
+            logging.info(f'\t{key} ({val.dtype.kind}{val.dtype.shape if val.dtype.shape else ""}): {val.shape}')
 
         super(H5FlowTestStage,self).run(source_name, source_slice, cache)
 

--- a/h5flow_modules/examples.py
+++ b/h5flow_modules/examples.py
@@ -6,7 +6,6 @@ class ExampleGenerator(H5FlowGenerator):
     class_version = '0.0.0'
 
     # best practice is to declare default values as class attributes
-    default_max_value = 2**32-1
     default_chunk_size = 1024
     default_iterations = 10
 
@@ -14,7 +13,6 @@ class ExampleGenerator(H5FlowGenerator):
         super(ExampleGenerator,self).__init__(**params)
 
         # get parameters from the params list
-        self.max_value = params.get('max_value', self.default_max_value)
         self.chunk_size = params.get('chunk_size', self.default_chunk_size)
 
         # prepare anything needed for the loop
@@ -33,7 +31,6 @@ class ExampleGenerator(H5FlowGenerator):
         self.data_manager.set_attrs(self.dset_name,
             classname=self.classname,
             class_version=self.class_version,
-            max_value=self.max_value,
             chunk_size=self.chunk_size,
             end_position=self.end_position
             )
@@ -44,9 +41,10 @@ class ExampleGenerator(H5FlowGenerator):
             return H5FlowGenerator.EMPTY
         self.iteration += 1
 
-        # just append random data
+        # just append data equivalent to the current index in the file
         next_slice = self.data_manager.reserve_data(self.dset_name, self.chunk_size)
-        self.data_manager.write_data(self.dset_name, next_slice, np.random.randint(self.max_value, size=self.chunk_size))
+        data = np.arange(next_slice.start, next_slice.stop)
+        self.data_manager.write_data(self.dset_name, next_slice, data)
 
         # return slice into newly added data
         return next_slice
@@ -71,9 +69,9 @@ class ExampleStage(H5FlowStage):
             )
 
         # then set up any new datasets that will be added (including references)
-        dtype = self.data_manager.get_dset(source_name).dtype
-        self.data_manager.create_dset(self.output_dset, dtype=dtype)
-        self.data_manager.create_ref(source_name, self.output_dset)
+        dtype = self.data_manager.get_dset(source_name).dtype # get the dtype of an existing dataset
+        self.data_manager.create_dset(self.output_dset, dtype=dtype) # create a new dataset
+        self.data_manager.create_ref(source_name, self.output_dset) # create a new reference table (source -> output)
 
     def run(self, source_name, source_slice, cache):
         # manipulate data from cache
@@ -89,9 +87,10 @@ class ExampleStage(H5FlowStage):
         self.data_manager.write_data(self.output_dset, new_slice, data)
 
         # To add references to the output file:
-        #  1. create an (N,2) array with parent->child indices (just 1:1 here)
-        parent_idcs = np.arange(source_slice.start, source_slice.stop).reshape(-1,1)
-        child_idcs = np.arange(new_slice.start, new_slice.stop).reshape(-1,1)
-        ref = np.concatenate((parent_idcs, child_idcs), axis=-1)
+        #  1. create an (N,2) array with parent->child indices (this does parent idx->0-10 child index)
+        parent_idcs = np.arange(source_slice.start, source_slice.stop).reshape(-1,1,1)
+        child_idcs = np.clip(np.arange(new_slice.start, new_slice.start+10).reshape(1,-1,1) + parent_idcs - source_slice.start,0,new_slice.stop-1)
+        parent_idcs, child_idcs = np.broadcast_arrays(parent_idcs, child_idcs)
+        ref = np.unique(np.concatenate((parent_idcs, child_idcs), axis=-1).reshape(-1,2), axis=0) # reshape to (parent, child), and only use unique references (repeats can be used)
         #  2. then write them into the file (no space reservation needed)
         self.data_manager.write_ref(source_name, self.output_dset, ref)

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -5,6 +5,7 @@ from mpi4py import MPI
 import numpy as np
 
 from h5flow.data import H5FlowDataManager
+from h5flow.data import ref_region_dtype, dereference
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
@@ -64,13 +65,15 @@ def empty_testref(datamanager, empty_testdset):
 def test_create_ref(datamanager, empty_testref):
     dm = datamanager
     # check that ref dataset opens and has correct type
-    assert dm.get_ref(*empty_testref).dtype == h5py.regionref_dtype
+    assert dm.get_ref(*empty_testref)[0].shape == (0,2)
+    assert dm.get_ref(*empty_testref)[-1] == (0,1)
+    assert dm.get_ref_region(*empty_testref).dtype == ref_region_dtype
     # check that ref dataset is still empty
-    assert len(dm.get_ref(*empty_testref)) == 0
-    assert len(dm.get_ref_valid(*empty_testref)) == 0
+    assert len(dm.get_ref(*empty_testref)[0]) == 0
+    assert len(dm.get_ref_region(*empty_testref)) == 0
 
 @pytest.fixture
-def full_testdset(datamanager, empty_testdset):
+def full_testdset(datamanager, empty_testdset, empty_testref):
     dm = datamanager
     sl = dm.reserve_data(empty_testdset, 100)
     dm.write_data(empty_testdset, sl, rank)
@@ -84,23 +87,30 @@ def test_write_dset(datamanager, full_testdset):
     assert all(dm.get_dset(full_testdset[0])[full_testdset[1]] == rank)
 
 @pytest.fixture
-def full_testref(datamanager, full_testdset, empty_testref):
+def full_testref(datamanager, empty_testref, full_testdset):
     dm = datamanager
-    n = full_testdset[1].stop - full_testdset[1].start
-    sl = dm.reserve_ref(*empty_testref, n)
-    dm.write_ref(*empty_testref, sl, [full_testdset[1] for _ in range(sl.start, sl.stop)])
-    return empty_testref, sl
+    ref_idcs = np.r_[full_testdset[1]].reshape(1,-1,1)
+    idcs = np.r_[full_testdset[1]].reshape(-1,1,1)
+    idcs,ref_idcs = np.broadcast_arrays(idcs,ref_idcs)
+    ref = np.concatenate((idcs,ref_idcs), axis=-1).reshape(-1,2)
+    dm.write_ref(*empty_testref, ref)
+    return empty_testref, full_testdset[-1]
 
 def test_write_ref(datamanager, full_testdset, full_testref):
     dm = datamanager
+    n = len(dm.get_dset(full_testdset[0]))
     # check that we have access to the *full* ref dataset after writing
-    assert len(dm.get_ref(*full_testref[0])) == size*100
+    assert len(dm.get_ref(*full_testref[0])[0]) == size * 100**2
     # check that child attribute is accessible and correct
-    assert dm.fh[dm.get_ref(*full_testref[0]).attrs['child']] == dm.get_dset(full_testdset[0])
-    ref = dm.get_ref(*full_testref[0])[full_testref[1]]
+    assert dm.fh[dm.get_ref(*full_testref[0])[0].attrs['child']] == dm.get_dset(full_testdset[0])
+    ref, ref_dir = dm.get_ref(*full_testref[0])
     # check that first of process' refs point to the correct chunk of the dataset
-    assert all(dm.get_ref_valid(*full_testref[0])[full_testref[1]])
-    assert all(dm.get_dset(full_testdset[0])[ref[0]] == dm.get_dset(full_testdset[0])[full_testdset[1]])
+    sel = full_testref[1]
+    ref_region = dm.get_ref_region(*full_testref[0])
+    assert all(ref_region[sel]['start'] != ref_region[sel]['stop'])
+
+    data = dereference(dm.get_dset(full_testdset[0]), ref, ref_region, sel=sel, ref_direction=ref_dir)
+    assert all([np.all(dm.get_dset(full_testdset[0])[sel] == d) for d in data])
 
 
 

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -109,7 +109,7 @@ def test_write_ref(datamanager, full_testdset, full_testref):
     ref_region = dm.get_ref_region(*full_testref[0])
     assert all(ref_region[sel]['start'] != ref_region[sel]['stop'])
 
-    data = dereference(dm.get_dset(full_testdset[0]), ref, ref_region, sel=sel, ref_direction=ref_dir)
+    data = dereference(sel, ref, dm.get_dset(full_testdset[0]), ref_region, ref_direction=ref_dir)
     assert all([np.all(dm.get_dset(full_testdset[0])[sel] == d) for d in data])
 
 


### PR DESCRIPTION
Moves to index-based references which allow much greater flexibility than hdf5 region references. In particular

 - index-based references can be translated into NumPy fancy-index operations on a pre-loaded dataset array, this is orders of magnitude faster than loading data via list comprehension
 - index-based references preserve bi-directional reference information
 - there is greater support within hdf5 for using simple datasets (ie index-based references) compared to special datasets (ie region references). In particular, region references are not allowed in parallel hdf5