### PR TITLE
Upgrade/add dereference chain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,10 +218,22 @@ are returned from one call to ``dereference`` in another::
         region = f['/B/ref/C/ref_region'], shape: (M,)
         mask = a2b_ref.mask.ravel() # use the mask that comes along from the previous dereferencing, shape: (n*l,)
     )
-    b2a2c.shape # (n*l,k), where k is the max number of a->c references
-    b2a2c.reshape(b2a_ref.shape,-1).shape # (n,l,k), broadcast-able back into a2b
+    a2b2c.shape # (n*l,k), where k is the max number of a->c references
+    a2b2c.reshape(b2a_ref.shape,-1).shape # (n,l,k), broadcast-able back into a2b
 
 This can be repeated many times to access ``B -> A -> C -> D -> ...`` references.
+
+An additional helper function ``dereference_chain`` is provided to make this easier.::
+
+    from h5flow.data import dereference_chain
+
+    sel = slice(0, 1000) # indices of A, shape: (n,)
+    refs = [f['/A/ref/B/ref'], f['/B/ref/C/ref']] # chain of references to load (A->B,B->C)
+    regions = [f['/A/ref/B/ref_region'], f['/B/ref/C/ref_region']] # lookup regions (for A and B)
+    ref_dir = [(0,1),(0,1)] # reference direction to use for each reference (defaults to (0,1))
+
+    a2b2c = dereference_chain(sel, refs, f['/C/data'], region=regions, ref_directions=ref_dir)
+    a2b2c.shape # (n,l,k)
 
 h5flow workflow
 ===============

--- a/h5flow/data/lib.py
+++ b/h5flow/data/lib.py
@@ -66,12 +66,12 @@ def dereference_chain(sel, refs, data=None, regions=None, mask=None, ref_directi
 
     '''
     sel = np.r_[sel]
-    mask = np.zeros_like(sel, dtype=bool) | mask
+    mask = np.zeros_like(sel, dtype=bool) | (mask if mask else False)
     sel = ma.array(sel, mask=mask)
     shape = (len(sel),)
     dref = None
 
-    n_steps = len(refs)
+    nsteps = len(refs)
     for i in range(nsteps):
         dset = data if i == nsteps-1 else None
         ref = refs[i]
@@ -121,7 +121,7 @@ def dereference(sel, ref, data=None, region=None, mask=None, ref_direction=(0,1)
     sel_idcs = np.r_[sel][~sel_mask] if sel_mask is not None else np.r_[sel]
     n_elem = len(sel_idcs) if sel_mask is None else len(sel_mask)
 
-    return_dtype = data.dtype if not indices_only else sel_idcs.dtype
+    return_dtype = data.dtype if not indices_only else ref.dtype
 
     if not len(sel_idcs) and n_elem:
         # special case for if there is nothing selected in the mask

--- a/tests/test_data_lib.py
+++ b/tests/test_data_lib.py
@@ -25,7 +25,7 @@ def full_testfile(testfile):
     dm.create_ref('A', 'B')
     dm.create_ref('C', 'B')
 
-    data_a = np.arange(10)
+    data_a = np.arange(10*rank,10*(rank+1))
     data_b = 10*np.broadcast_to(np.expand_dims(data_a,-1),(10,10)) + np.expand_dims(np.arange(10),axis=0)
     data_c = 10*np.broadcast_to(np.expand_dims(data_b,-1),(10,10,10)) + np.expand_dims(np.arange(10),axis=0)
 
@@ -43,9 +43,9 @@ def full_testfile(testfile):
     ref = np.unique(np.c_[data_c.ravel(), np.broadcast_to(np.expand_dims(data_b,-1), data_c.shape).ravel()], axis=0)
     dm.write_ref('C','B',ref)
 
-    assert len(dm.fh['A/data']) == 10
-    assert len(dm.fh['B/data']) == 100
-    assert len(dm.fh['C/data']) == 1000
+    assert len(dm.fh['A/data']) == 10 * size
+    assert len(dm.fh['B/data']) == 100 * size
+    assert len(dm.fh['C/data']) == 1000 * size
 
     return dm.fh, ('A', 'B', 'C')
 
@@ -64,7 +64,6 @@ def test_dereference(full_testfile):
     ref = fh[f'{a}/ref/{b}/ref']
     dset = fh[f'{b}/data']
     region = fh[f'{a}/ref/{b}/ref_region']
-
 
     data_no_reg = dereference(sel, ref, dset)
 

--- a/tests/test_data_lib.py
+++ b/tests/test_data_lib.py
@@ -1,0 +1,103 @@
+import pytest
+import h5py
+import os
+from mpi4py import MPI
+import numpy as np
+import numpy.ma as ma
+
+from h5flow.data import H5FlowDataManager
+from h5flow.data import *
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+@pytest.fixture
+def testfile(mpi_tmp_path):
+    return os.path.join(mpi_tmp_path, 'test.h5')
+
+@pytest.fixture
+def full_testfile(testfile):
+    dm = H5FlowDataManager(testfile)
+    dm.create_dset('A', int)
+    dm.create_dset('B', int)
+    dm.create_dset('C', int)
+    dm.create_ref('A', 'B')
+    dm.create_ref('C', 'B')
+
+    data_a = np.arange(10)
+    data_b = 10*np.broadcast_to(np.expand_dims(data_a,-1),(10,10)) + np.expand_dims(np.arange(10),axis=0)
+    data_c = 10*np.broadcast_to(np.expand_dims(data_b,-1),(10,10,10)) + np.expand_dims(np.arange(10),axis=0)
+
+    sl_a = dm.reserve_data('A', len(np.unique(data_a.ravel())))
+    dm.write_data('A', sl_a, np.unique(data_a.ravel()))
+
+    sl_b = dm.reserve_data('B', len(np.unique(data_b.ravel())))
+    dm.write_data('B', sl_b, np.unique(data_b.ravel()))
+
+    sl_c = dm.reserve_data('C', len(np.unique(data_c.ravel())))
+    dm.write_data('C', sl_c, np.unique(data_c.ravel()))
+
+    ref = np.unique(np.c_[np.broadcast_to(np.expand_dims(data_a,-1), data_b.shape).ravel(), data_b.ravel()], axis=0)
+    dm.write_ref('A','B',ref)
+    ref = np.unique(np.c_[data_c.ravel(), np.broadcast_to(np.expand_dims(data_b,-1), data_c.shape).ravel()], axis=0)
+    dm.write_ref('C','B',ref)
+
+    assert len(dm.fh['A/data']) == 10
+    assert len(dm.fh['B/data']) == 100
+    assert len(dm.fh['C/data']) == 1000
+
+    return dm.fh, ('A', 'B', 'C')
+
+def test_print_ref(full_testfile):
+    fh, _ = full_testfile
+    print_ref(fh)
+
+def test_print_data(full_testfile):
+    fh,_ = full_testfile
+    print_data(fh)
+
+def test_dereference(full_testfile):
+    fh,(a,b,c) = full_testfile
+
+    sel = slice(0,10)
+    ref = fh[f'{a}/ref/{b}/ref']
+    dset = fh[f'{b}/data']
+    region = fh[f'{a}/ref/{b}/ref_region']
+
+
+    data_no_reg = dereference(sel, ref, dset)
+
+    data_reg = dereference(sel, ref, dset, region=region)
+
+    data_idx = dereference(sel, ref, dset, region=region, indices_only=True)
+
+    data_list = dereference(sel, ref, dset, region=region, as_masked=False)
+
+    assert ma.all(data_no_reg == data_reg)
+    assert data_reg.shape == (10,10)
+    assert data_reg.shape == data_idx.shape
+    assert np.sum(data_reg.mask) == 0
+    assert len(data_list) == 10
+    assert isinstance(data_list, list)
+    assert all([len(a) == 10 for a in data_list])
+
+def test_dereference_chain(full_testfile):
+    fh,(a,b,c) = full_testfile
+
+    sel = slice(0,10)
+    refs = [fh[f'{a}/ref/{b}/ref'], fh[f'{c}/ref/{b}/ref']]
+    dset = fh[f'{c}/data']
+    regions = [fh[f'{a}/ref/{b}/ref_region'], fh[f'{b}/ref/{c}/ref_region']]
+    ref_dir = [(0,1), (1,0)]
+
+    data_no_reg = dereference_chain(sel, refs, dset)
+
+    data_reg = dereference_chain(sel, refs, dset, regions=regions)
+
+    data_idx = dereference_chain(sel, refs, dset, regions=regions, indices_only=True)
+
+    assert ma.all(data_no_reg == data_reg)
+    assert data_reg.shape == (10,10,1)
+    assert data_reg.shape == data_idx.shape
+    assert np.sum(data_reg.mask) == 0

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,11 @@
+import pytest
+import os
+
+from h5flow import run
+
+@pytest.fixture
+def testfile(mpi_tmp_path):
+    return os.path.join(mpi_tmp_path, 'test.h5')
+
+def test_example(testfile):
+    run('example_config.yaml', testfile, verbose=2)


### PR DESCRIPTION
Adds a helper function (``dereference_chain``) to `h5flow.data.lib` facilitate complicated dereferencing schemes which involve traversing multiple references between different datasets.

Makes the unnecessary ``data`` argument optional for both ``dereference_chain`` and ``dereference`` if ``indices_only`` flag is enabled.

Includes update to README and new tests.