### PR TITLE
Fix/fix drop dataset list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Linting and tests
+
+on:
+  push:
+    branches: [ develop, main ]
+  pull_request:
+    branches: [ develop, main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        activate-environment: test
+        environment-file: environment.yml
+    - name: Install
+      run: |
+        conda install flake8
+        pip install --no-deps .
+    - name: Lint
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Run tests
+      run: |
+        pytest
+        mpiexec pytest --with-mpi
+    - name: Test example
+      run: |
+        mpiexec h5flow -vv -c example_config.yaml -o test.h5

--- a/README.rst
+++ b/README.rst
@@ -295,7 +295,8 @@ The ``source`` defines the loop source dataset. By default, you may specify an
 existing dataset and an ``H5FlowDatasetLoopGenerator`` will be used. ``stages``
 defines the names and sequential order of the analysis stages should be executed
 on each data chunk provided by the generator. Optionally, ``drop`` defines a list
-of datasets to delete from the output file after the run loop completes.
+of dataset paths to save in a temporary file to be deleted at the end of the
+workflow.
 
 generators
 ~~~~~~~~~~

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -3,8 +3,8 @@
 flow:
   source: input # uncomment to use the example generator
   # source: 'input/index' # uncomment to loop over an existing dataset
-  stages: [example_stage0, example_stage1, print]
-  drop: []
+  stages: [example_stage0, example_stage1, example_stage2, print]
+  drop: ['example_stage2/example']
 
 input:
   classname: ExampleGenerator
@@ -30,6 +30,11 @@ example_stage1:
         path: ['example_stage0/example', 'input/index']
   params:
     output_dset: 'example_stage1/example'
+
+example_stage2:
+  classname: ExampleStage
+  params:
+    output_dset: 'example_stage2/example' # remove this dataset from output file
 
 print: # print the contents of the cache if in verbose mode
   classname: H5FlowTestStage

--- a/h5flow/core/h5_flow_manager.py
+++ b/h5flow/core/h5_flow_manager.py
@@ -69,7 +69,7 @@ class H5FlowManager(object):
             :param config: ``dict``, parsed yaml config for workflow
 
         '''
-        self.data_manager = H5FlowDataManager(output_filename)
+        self.data_manager = H5FlowDataManager(output_filename, drop_list=self.drop_list)
 
     def configure_generator(self, input_filename, config, start_position, end_position):
         '''
@@ -224,19 +224,7 @@ class H5FlowManager(object):
             self.comm.barrier()
 
         logging.debug(f'close data manager')
-        for drop in self.drop_list:
-            self.data_manager.delete(drop)
-        self.data_manager.close_file()
-        # if H5FLOW_MPI:
-        #     self.comm.barrier()
-        # if len(self.drop_list) and self.rank == 0:
-        #     # repacks the hdf5 file to recover space from dropped datasets
-        #     tempfile = os.path.join(os.path.dirname(self.data_manager.filepath), '.temp-{}.h5'.format(time.time()))
-        #     subprocess.run(['h5repack', self.data_manager.filepath, tempfile])
-        #     os.replace(tempfile, self.data_manager.filepath)
-        #     os.remove(tempfile)
-        # if H5FLOW_MPI:
-        #     self.comm.barrier()
+        self.data_manager.finish()
 
     def update_cache(self, cache, source_name, source_slice, requirements):
         '''

--- a/h5flow/data/lib.py
+++ b/h5flow/data/lib.py
@@ -198,6 +198,9 @@ def dereference(sel, ref, data=None, region=None, mask=None, ref_direction=(0,1)
     # first using only the unique references and then casting it back into the
     # original selection
     ref_mask = np.isin(ref[:,ref_direction[0]], sel_idcs)
+    if not np.any(ref_mask):
+        # special case if no valid references for selection
+        return ma.array(np.empty((n_elem,1), dtype=return_dtype), mask=True)
 
     # only use references that are relevant to the selection
 


### PR DESCRIPTION
Updates the drop dataset functionality to save temporary datasets to a temporary file, rather than saving to the same output file. This is to overcome the fact that hdf5 flies do not recover disk space after deleting datasets.