### PR TITLE
reverts pyyaml-include version

### DIFF
--- a/environment-nompi.yml
+++ b/environment-nompi.yml
@@ -9,4 +9,4 @@ dependencies:
   - tqdm
   - pytest
   - pip:
-    - pyyaml-include
+    - pyyaml-include==1.4.1

--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,5 @@ dependencies:
   - pytest
   - pytest-mpi
   - pip:
-    - pyyaml-include
+    - pyyaml-include==1.4.1
     - h5py --no-binary=h5py


### PR DESCRIPTION
back to version 1.4.1, before breaking changes introduced in v2. addresses #24 